### PR TITLE
Updated count permissions to userpermissions

### DIFF
--- a/app/Http/Middleware/PermissionsRequiredMiddleware.php
+++ b/app/Http/Middleware/PermissionsRequiredMiddleware.php
@@ -48,7 +48,7 @@ class PermissionsRequiredMiddleware {
 				return $next($request);
 			}
 		} else {
-			if (count($permissions) > 0)
+			if (count($userPermissions) > 0)
 			{
 				// Allow the request.
 				return $next($request);


### PR DESCRIPTION
When not using permissions_require_all this seems to allow all roles though.
The count of the permissions needs to check the userPermissions. 
A small oversight?
